### PR TITLE
Closes #39 by fixing the mispelling of SUCESS to SUCCESS.  This meant…

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -308,7 +308,7 @@
                                                                                 if [ ${ _environment-variable "ALL" } == ${ _environment-variable "SUCCESS" } ] && [ ${ _environment-variable "FAILURE" } == 0 ]
                                                                                 then
                                                                                     ${ pkgs.coreutils }/bin/echo ${ _environment-variable "SUCCESS" } > $out/SUCCESS
-                                                                                elif [ ${ _environment-variable "ALL" } == $(( ${ _environment-variable "SUCESS" } + ${ _environment-variable "FAILURE" } )) ]
+                                                                                elif [ ${ _environment-variable "ALL" } == $(( ${ _environment-variable "SUCCESS" } + ${ _environment-variable "FAILURE" } )) ]
                                                                                 then
                                                                                     ${ pkgs.coreutils }/bin/echo ${ _environment-variable "FAILURE" } > $out/FAILURE
                                                                                 fi


### PR DESCRIPTION
… SUCESS+FAILURE<ALL which meant that if there was a predicted failure it would be calculated as an unpredicted failure.